### PR TITLE
Missing input filter for useSingle

### DIFF
--- a/src/pages/meteor-demo.tsx
+++ b/src/pages/meteor-demo.tsx
@@ -56,6 +56,9 @@ const SelectedDocument = ({
 }) => {
   const { document, loading, error } = useSingle({
     model: VulcanResource,
+    input: {
+      id: selectedDocumentId
+    },
     queryOptions: {
       skip: !selectedDocumentId, // do not trigger if no document is selected
     },


### PR DESCRIPTION
When pressing select button, the id of the document should be used in the query to display the correct document in `useSingle`